### PR TITLE
fix: branch name missing from `releaseVersion`

### DIFF
--- a/pdk-prerelease/action.yml
+++ b/pdk-prerelease/action.yml
@@ -90,7 +90,7 @@ runs:
 
         if [ "$MODE" == "pull_request" ]; then
           branch=$(git branch --show-current)
-          releaseVersion="dev-$PR_NUMBER-$branch"
+          releaseVersion="dev-$PR_NUMBER-$GITHUB_HEAD_REF"
 
           if [ "$DEBUG" == "1" ]; then
             echo "branch=$branch" 


### PR DESCRIPTION
fix branch name missing from the `releaseVersion` when running the pdk-prerelease action from a PR

(note: not sure how to test changes here)

attempting to fix incomplete version strings, see  example: https://github.com/myparcelnl/prestashop/actions/runs/11442140509/job/31831929778#step:2:2037 