### PR TITLE
fix: dev deps installed on pdk-setup-upgrade

### DIFF
--- a/pdk-semantic-release/action.yml
+++ b/pdk-semantic-release/action.yml
@@ -86,6 +86,10 @@ runs:
       with:
         app-id: ${{ inputs.app-id }}
         private-key: ${{ inputs.private-key }}
+        php-version: ${{ inputs.php-version }}
+        node-version: ${{ inputs.node-version }}
+        yarn-args: ${{ inputs.yarn-args }}
+        composer-dev: false
 
     - uses: myparcelnl/actions/pdk-cache@v4
       with:


### PR DESCRIPTION
fix dev dependencies being installed by default on pdk-setup-upgrade, by providing the same args to `php-setup-upgrade` as `pdk-setup` already had.