### PR TITLE
fix: remove condition preventing assign author action from ever running

### DIFF
--- a/pr-assign-author/action.yml
+++ b/pr-assign-author/action.yml
@@ -14,7 +14,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - uses: myparcelnl/actions/get-github-token@v4
       id: token
@@ -24,8 +24,7 @@ runs:
         private-key: ${{ inputs.private-key }}
 
     - name: 'Assign author'
-      uses: actions/github-script@v7
-      if: steps.check.outputs.assignable == 'true'
+      uses: actions/github-script@v9
       with:
         github-token: ${{ steps.token.outputs.token }}
         #language=javascript
@@ -37,17 +36,21 @@ runs:
 
           const author = context.payload.pull_request.user.login;
 
-          const permission = await github.rest.repos.getCollaboratorPermissionLevel({
+          const response = await github.rest.repos.getCollaboratorPermissionLevel({
             ...context.repo,
             username: author
           });
+          
+          const permission = response.permission ?? response.data.permission;
+          
+          const allowedPermissions = [ 'admin', 'write', 'push', 'maintain' ];
 
-          if (permission.permission !== 'admin' && permission.permission !== 'write') {
+          if (!allowedPermissions.includes(permission)) {
             console.log(`Author "${author}" does not have the required permissions to be assigned.`);
             return;
           }
 
-          github.rest.issues.addAssignees({
+          await github.rest.issues.addAssignees({
             ...context.repo,
             issue_number: context.payload.pull_request.number,
             assignees: [author]


### PR DESCRIPTION
# PR Info
## Problem

The 'Assign author' step never executes, because the condition refers to the output of a non-existent step.

<img width="365" height="68" alt="image" src="https://github.com/user-attachments/assets/b20d5ed2-2e3c-4667-bc96-4c093bdf74fa" />

No 'check' step exists, so above condition is never satisfied.

## PR Contents

- Bump 'actions/checkout' and 'actions/github-script' actions
- Remove if clause from 'Assign author' step
- Make response handling for github.rest calls more robust