### PR TITLE
feat(pr-label-by-review): exclude bot reviews from approval count

### DIFF
--- a/pr-label-by-review/action.yml
+++ b/pr-label-by-review/action.yml
@@ -26,6 +26,14 @@ inputs:
     description: 'Type of protection to check for. Can be either "branch-protection" or "rulesets".'
     default: 'branch-protection'
 
+  ignore-bots:
+    description: 'Ignore reviews from bot accounts (e.g. Copilot) when counting approvals.'
+    default: 'true'
+
+  ignore-reviewers:
+    description: 'Comma-separated list of reviewer logins to ignore when counting approvals.'
+    default: ''
+
 runs:
   using: composite
   steps:
@@ -102,18 +110,32 @@ runs:
             pull_number: context.payload.pull_request.number
           });
 
+          const ignoreBots = '${{ inputs.ignore-bots }}' === 'true';
+          const ignoredLogins = new Set(
+            '${{ inputs.ignore-reviewers }}'
+              .split(',')
+              .map(login => login.trim().toLowerCase())
+              .filter(Boolean)
+          );
+
+          const isIgnored = (review) =>
+            (ignoreBots && review.user.type === 'Bot') ||
+            ignoredLogins.has(review.user.login.toLowerCase());
+
           // Filter out duplicate reviews from the same user and keep only the last review from each user
           const userReviews = new Map();
 
-          reviews.data.forEach(review => {
-            const { login } = review.user;
+          reviews.data
+            .filter(review => !isIgnored(review))
+            .forEach(review => {
+              const { login } = review.user;
 
-            if (!userReviews.has(login)) {
-              userReviews.set(login, review);
-            } else if (userReviews.get(login).submitted_at < review.submitted_at) {
-              userReviews.set(login, review);
-            }
-          });
+              if (!userReviews.has(login)) {
+                userReviews.set(login, review);
+              } else if (userReviews.get(login).submitted_at < review.submitted_at) {
+                userReviews.set(login, review);
+              }
+            });
 
           const userReviewsArray = Array.from(userReviews.values());
 


### PR DESCRIPTION
## Problem

\`pr-label-by-review\` counts every unique reviewer login toward \`required-approvals\`. GitHub Copilot (and any other bot reviewer) approving a PR counts the same as a human, so the \`approved\` label gets added one human approval short of the configured threshold.

## Fix

Filter reviews before counting unique approvals:

- **\`ignore-bots\`** (default \`true\`) — drops reviews where \`review.user.type === 'Bot'\` (Copilot et al). Zero config needed in consumer repos.
- **\`ignore-reviewers\`** — comma-separated reviewer logins to ignore. Escape hatch for setups where an App-based approver (also \`Bot\` type) *should* still count — name humans/bots explicitly instead.

## Compatibility

- Human reviews are \`User\` type — unaffected.
- Behavior change: workflows that (unintentionally) relied on a bot approval counting will now require one more human approval. This was the unintended behavior being fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)