### PR TITLE
feat: bump action versions

### DIFF
--- a/get-github-token/action.yml
+++ b/get-github-token/action.yml
@@ -21,6 +21,7 @@ inputs:
 
   skip-token-revoke:
     description: 'If truthy, the token will not be revoked when the current job is complete'
+    default: 'false'
     required: false
 
   github-api-url:
@@ -48,7 +49,7 @@ runs:
 
     - id: app
       if: inputs.token == '' && (inputs.app-id != '' || inputs.private-key != '')
-      uses: myparcelnl/actions/setup-app-credentials@v4
+      uses: myparcelnl/actions/setup-app-credentials@v5
       with:
         app-id: ${{ inputs.app-id }}
         private-key: ${{ inputs.private-key }}

--- a/pr-assign-author/action.yml
+++ b/pr-assign-author/action.yml
@@ -16,7 +16,7 @@ runs:
   steps:
     - uses: actions/checkout@v6
 
-    - uses: myparcelnl/actions/get-github-token@v4
+    - uses: myparcelnl/actions/get-github-token@v5
       id: token
       with:
         token: ${{ inputs.token }}

--- a/pr-label-by-review/action.yml
+++ b/pr-label-by-review/action.yml
@@ -37,9 +37,9 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
-    - uses: myparcelnl/actions/get-github-token@v4
+    - uses: myparcelnl/actions/get-github-token@v5
       id: token
       with:
         token: ${{ inputs.token }}
@@ -49,7 +49,7 @@ runs:
     - name: 'Get required approvals from branch protection'
       id: branch-protection
       if: inputs.required-approvals == '' && inputs.protection-type == 'branch-protection'
-      uses: actions/github-script@v7
+      uses: actions/github-script@v9
       with:
         github-token: ${{ steps.token.outputs.token }}
         #language=javascript
@@ -67,7 +67,7 @@ runs:
     - name: 'Get required approvals from rule sets'
       id: rulesets
       if: inputs.required-approvals == '' && inputs.protection-type == 'rulesets'
-      uses: actions/github-script@v7
+      uses: actions/github-script@v9
       with:
         github-token: ${{ steps.token.outputs.token }}
         #language=javascript
@@ -99,7 +99,7 @@ runs:
 
     - name: 'Collect pull request reviews'
       id: check
-      uses: actions/github-script@v7
+      uses: actions/github-script@v9
       with:
         github-token: ${{ steps.token.outputs.token }}
         #language=javascript
@@ -149,7 +149,7 @@ runs:
           core.setOutput('changes-requested', changesRequested ? 'true' : 'false');
 
     - name: 'Add "approved" label'
-      uses: actions/github-script@v7
+      uses: actions/github-script@v9
       if: steps.check.outputs.approved == 'true' && !contains(github.event.pull_request.labels.*.name, inputs.label-approved)
       with:
         github-token: ${{ steps.token.outputs.token }}
@@ -163,7 +163,7 @@ runs:
           });
 
     - name: 'Add "changes requested" label'
-      uses: actions/github-script@v7
+      uses: actions/github-script@v9
       if: steps.check.outputs.changes-requested == 'true' && !contains(github.event.pull_request.labels.*.name, inputs.label-changes-requested)
       with:
         github-token: ${{ steps.token.outputs.token }}
@@ -177,7 +177,7 @@ runs:
           });
 
     - name: 'Remove "approved" label'
-      uses: actions/github-script@v7
+      uses: actions/github-script@v9
       if: contains(github.event.pull_request.labels.*.name, inputs.label-approved) && (steps.check.outputs.approved == 'false')
       with:
         github-token: ${{ steps.token.outputs.token }}
@@ -191,7 +191,7 @@ runs:
           });
 
     - name: 'Remove "changes requested" label'
-      uses: actions/github-script@v7
+      uses: actions/github-script@v9
       if: contains(github.event.pull_request.labels.*.name, inputs.label-changes-requested) && (steps.check.outputs.changes-requested == 'false')
       with:
         github-token: ${{ steps.token.outputs.token }}

--- a/setup-app-credentials/action.yml
+++ b/setup-app-credentials/action.yml
@@ -20,6 +20,7 @@ inputs:
 
   skip-token-revoke:
     description: 'If truthy, the token will not be revoked when the current job is complete'
+    default: 'false'
     required: false
 
   github-api-url:
@@ -46,10 +47,10 @@ outputs:
 runs:
   using: composite
   steps:
-    - uses: actions/create-github-app-token@v1
+    - uses: actions/create-github-app-token@v3
       id: generate-token
       with:
-        app-id: ${{ inputs.app-id }}
+        client-id: ${{ inputs.app-id }}
         private-key: ${{ inputs.private-key }}
         owner: ${{ inputs.owner }}
         repositories: ${{ inputs.repositories }}

--- a/setup-git-credentials/action.yml
+++ b/setup-git-credentials/action.yml
@@ -20,6 +20,7 @@ inputs:
 
   skip-token-revoke:
     description: 'If truthy, the token will not be revoked when the current job is complete'
+    default: 'false'
     required: false
 
   github-api-url:
@@ -46,7 +47,7 @@ outputs:
 runs:
   using: composite
   steps:
-    - uses: myparcelnl/actions/setup-app-credentials@v4
+    - uses: myparcelnl/actions/setup-app-credentials@v5
       id: credentials
       with:
         app-id: ${{ inputs.app-id }}


### PR DESCRIPTION
# PR Info

[CLOUD-1835](https://internal.jira.dmp.zone/browse/CLOUD-1835)
[CLOUD-1873](https://internal.jira.dmp.zone/browse/CLOUD-1873)

## Problem

Github Actions is deprecating Node 20 actions.
This PR bumps some GHA actions to their latest available versions, which use Node 24.

## PR Contents

I've limited the scope of this PR to actions used by the [core-api repo](https://github.com/mypadev/core-api)

# Test
In a test repository I used the action that's on the 'bump-used-action-versions' branch, and they ran successfully.
<img width="632" height="303" alt="image" src="https://github.com/user-attachments/assets/371f097c-d0bc-4a08-8b17-90487db45d98" />

<img width="916" height="518" alt="image" src="https://github.com/user-attachments/assets/f8ad707f-b776-4c5f-8704-fae868630269" />


[CLOUD-1835]: https://myparcelnl.atlassian.net/browse/CLOUD-1835?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CLOUD-1873]: https://myparcelnl.atlassian.net/browse/CLOUD-1873?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ